### PR TITLE
Spring beans support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ public class Sample {
 }
 ```
 
+```java
+
+// config: needed to allow autowiring of dependencies in custom validators
+@Bean
+public LocalValidatorFactoryBean localValidatorFactoryBean() {
+    return new LocalValidatorFactoryBean();
+}
+
+public class Sample {
+
+    @SpELAssert(value = "@myService.doSomeCalculation(#this) > 42")
+    private int value;
+}
+```
 
 Maven
 -----

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,32 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <!-- minimal suitable version -->
+            <version>3.0.5.RELEASE</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <!-- minimal suitable version -->
+            <version>3.0.5.RELEASE</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!--//// Test ////-->
 
         <dependency>

--- a/src/main/java/cz/jirutka/validator/spring/SpELAssertValidator.java
+++ b/src/main/java/cz/jirutka/validator/spring/SpELAssertValidator.java
@@ -60,6 +60,10 @@ public class SpELAssertValidator implements ConstraintValidator<SpELAssert, Obje
     private List<Method> functions = new LinkedList<>();
 
     @Autowired
+    public void setApplicationContext(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
     private ApplicationContext applicationContext;
 
     public void initialize(SpELAssert constraint) {

--- a/src/main/java/cz/jirutka/validator/spring/SpELAssertValidator.java
+++ b/src/main/java/cz/jirutka/validator/spring/SpELAssertValidator.java
@@ -26,10 +26,9 @@ package cz.jirutka.validator.spring;
 import cz.jirutka.validator.spring.support.RelaxedBooleanTypeConverterDecorator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.expression.EvaluationContext;
-import org.springframework.expression.Expression;
-import org.springframework.expression.ExpressionParser;
-import org.springframework.expression.TypeConverter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.expression.*;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.expression.spel.support.StandardTypeConverter;
@@ -60,6 +59,8 @@ public class SpELAssertValidator implements ConstraintValidator<SpELAssert, Obje
     private Expression applyIfExpression;
     private List<Method> functions = new LinkedList<>();
 
+    @Autowired
+    private ApplicationContext applicationContext;
 
     public void initialize(SpELAssert constraint) {
         ExpressionParser parser = new SpelExpressionParser();
@@ -103,6 +104,14 @@ public class SpELAssertValidator implements ConstraintValidator<SpELAssert, Obje
 
         context.setRootObject(rootObject);
         context.setTypeConverter(TYPE_CONVERTER);
+        if (applicationContext != null) {
+            context.setBeanResolver(new BeanResolver() {
+                @Override
+                public Object resolve(EvaluationContext evaluationContext, String beanName) throws AccessException {
+                    return applicationContext.getBean(beanName);
+                }
+            });
+        }
 
         if (! functions.isEmpty()) {
             for (Method helper : functions) {

--- a/src/test/java/cz/jirutka/validator/spring/SpELAssertValidatorBeanAccessTest.java
+++ b/src/test/java/cz/jirutka/validator/spring/SpELAssertValidatorBeanAccessTest.java
@@ -33,7 +33,7 @@ public class SpELAssertValidatorBeanAccessTest implements ConstraintValidatorFac
     }
 
     @Test
-    public void test_valid_service_cll() {
+    public void test_valid_service_call() {
         Set<ConstraintViolation<MockBean>> constraintViolations = validator.validate(new MockBean("VALID"));
 
         assertThat(constraintViolations.size(), is(0));

--- a/src/test/java/cz/jirutka/validator/spring/SpELAssertValidatorBeanAccessTest.java
+++ b/src/test/java/cz/jirutka/validator/spring/SpELAssertValidatorBeanAccessTest.java
@@ -1,0 +1,78 @@
+package cz.jirutka.validator.spring;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.ApplicationContext;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import javax.validation.*;
+import java.util.Set;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+
+public class SpELAssertValidatorBeanAccessTest implements ConstraintValidatorFactory {
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    private Validator validator;
+
+    @BeforeTest
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        when(applicationContext.getBean("mockService")).thenReturn(new MockService());
+
+        Configuration<?> config = Validation.byDefaultProvider().configure();
+        config.constraintValidatorFactory(this);
+        ValidatorFactory factory = config.buildValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    public void test_valid_service_cll() {
+        Set<ConstraintViolation<MockBean>> constraintViolations = validator.validate(new MockBean("VALID"));
+
+        assertThat(constraintViolations.size(), is(0));
+    }
+
+    @Test
+    public void test_invalid_service_call() {
+        Set<ConstraintViolation<MockBean>> constraintViolations = validator.validate(new MockBean("INVALID"));
+
+        assertThat(constraintViolations.size(), is(1));
+        ConstraintViolation<MockBean> violation = constraintViolations.iterator().next();
+        assertThat(violation.getMessage(), is("must equal VALID"));
+    }
+
+    @Override
+    public <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> aClass) {
+        SpELAssertValidator validator = new SpELAssertValidator();
+        validator.setApplicationContext(applicationContext);
+        return (T) validator;
+    }
+
+    ////////// Mocks //////////
+
+    private static class MockBean {
+        @SpELAssert(value = "@mockService.isValid(#this)", message = "must equal VALID")
+        private String field;
+
+        public MockBean(String field) {
+            this.field = field;
+        }
+
+        public String getField() {
+            return field;
+        }
+    }
+
+    private static class MockService {
+        public boolean isValid(String value) {
+            return "VALID".equals(value);
+        }
+    }
+}


### PR DESCRIPTION
Hi Jakub,

This PR adds supports for accessing spring beans in validation expressions.
For that to work there must be a bean of type LocalValidatorFactoryBean in the application context so that uses it's own factory for creating validators (thus enabling autowiring). It should still work with the default validator factory, only then beans will not be available.

Best regards
Lukas