### PR TITLE
Support list of SpELAssert annotations in Java 8+

### DIFF
--- a/src/main/java/cz/jirutka/validator/spring/SpELAssert.java
+++ b/src/main/java/cz/jirutka/validator/spring/SpELAssert.java
@@ -26,6 +26,7 @@ package cz.jirutka.validator.spring;
 import javax.validation.Constraint;
 import javax.validation.Payload;
 import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -41,6 +42,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target({METHOD, FIELD, TYPE})
 @Constraint(validatedBy = SpELAssertValidator.class)
+@Repeatable(SpELAssert.List.class)
 public @interface SpELAssert {
 
     String message() default "{cz.jirutka.validator.spring.SpELAssert.message}";


### PR DESCRIPTION
Since Java 8 it is required to add the meta annotation [@Repeatable](https://docs.oracle.com/javase/tutorial/java/annotations/repeating.html) to an annotation if you want to be able to use it more than once on the same field